### PR TITLE
Change markdown example explanation tag to non-escaped syntax

### DIFF
--- a/templates/rspec_api_documentation/markdown_example.mustache
+++ b/templates/rspec_api_documentation/markdown_example.mustache
@@ -9,7 +9,7 @@
 ### {{ http_method }} {{ route }}
 {{# explanation }}
 
-{{ explanation }}
+{{{ explanation }}}
 {{/ explanation }}
 {{# has_parameters? }}
 


### PR DESCRIPTION
This allows us to write markdown syntax explanations on acceptance specs